### PR TITLE
fix: bound soundness checks in verify zero such that lhs will be 165 bits

### DIFF
--- a/src/secp256r1/bigint.cairo
+++ b/src/secp256r1/bigint.cairo
@@ -1,0 +1,37 @@
+from starkware.cairo.common.cairo_secp.bigint import BigInt3
+
+from src.secp256r1.constants import BASE
+
+// Returns a BigInt3 instance whose value is controlled by a prover hint.
+//
+// Soundness guarantee:
+// d0, d1 limbs are in the range [0, 2 * BASE).
+// d2 limb in the range [0, BASE)
+// Completeness guarantee (honest prover): the value is in reduced form and in particular,
+// each limb is in the range [0, BASE).
+//
+// Implicit arguments:
+//   range_check_ptr - range check builtin pointer.
+//
+// Hint arguments: value.
+func nondet_bigint3{range_check_ptr}() -> (res: BigInt3) {
+    let res: BigInt3 = [cast(ap + 3, BigInt3*)];
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import split
+
+        segments.write_arg(ids.res.address_, split(value))
+    %}
+    const MAX_SUM_BOUND = 2**128 - 2 * BASE; // Bound d0, d1 (each) in [0, 2*BASE)
+    const D2_BOUND = 2**128 - BASE; // Bound d2 in [0, BASE)
+
+    assert [range_check_ptr] = res.d0 + res.d1 + MAX_SUM_BOUND;
+
+    // Prepare the result
+    tempvar range_check_ptr = range_check_ptr + 5;
+    [range_check_ptr - 4] = res.d0, ap++;
+    [range_check_ptr - 3] = res.d1, ap++;
+    [range_check_ptr - 2] = res.d2, ap++;
+    assert [range_check_ptr - 1] = res.d2 + D2_BOUND;
+    static_assert &res + BigInt3.SIZE == ap - 1;
+    return (res=res);
+}

--- a/src/secp256r1/constants.cairo
+++ b/src/secp256r1/constants.cairo
@@ -13,9 +13,9 @@ const SECP_REM = 2**224 - 2**192 - 2**96 + 1;
 const BASE = 2 ** 86;
 
 // SECP_REM =  2**224 - 2**192 - 2**96 + 1
-const SECP_REM0 = 0x1;
-const SECP_REM1 = 0x3ffffffffffffffffffc00;
-const SECP_REM2 = 0xfffffffefffff;
+const SECP_REM0 = 1;
+const SECP_REM1 = -2**10;
+const SECP_REM2 = 0xffffffff00000;
 
 // P = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF
 const P0 = 0x3fffffffffffffffffffff;

--- a/src/secp256r1/ec.cairo
+++ b/src/secp256r1/ec.cairo
@@ -1,5 +1,7 @@
-from starkware.cairo.common.cairo_secp.bigint import BigInt3, UnreducedBigInt3, nondet_bigint3
+from starkware.cairo.common.cairo_secp.bigint import BigInt3, UnreducedBigInt3
 from starkware.cairo.common.cairo_secp.ec import EcPoint
+
+from src.secp256r1.bigint import nondet_bigint3
 from src.secp256r1.field import (
     is_zero,
     unreduced_mul,

--- a/src/secp256r1/signature.cairo
+++ b/src/secp256r1/signature.cairo
@@ -6,13 +6,13 @@ from starkware.cairo.common.cairo_secp.bigint import (
     BigInt3,
     UnreducedBigInt3,
     bigint_mul,
-    nondet_bigint3,
 )
 from starkware.cairo.common.cairo_secp.ec import EcPoint
 from starkware.cairo.common.math import assert_nn, assert_nn_le, assert_not_zero, unsigned_div_rem
 from starkware.cairo.common.math_cmp import RC_BOUND
 from starkware.cairo.common.uint256 import Uint256
 
+from src.secp256r1.bigint import nondet_bigint3
 from src.secp256r1.constants import (
     N0, N1, N2,
     B0, B1, B2,


### PR DESCRIPTION
after accounting for limbs being able to be 3*BASE our soundness checks were bound to 167bits causing LHS to be bigger than CAIRO prime. r1*BASE was inside 165 bits to begin with, for r2*BASE we had to shift some bits from SECP_REM1 limb into SECP_REM2 allowing it to fit inside 165 bits.